### PR TITLE
Better FileListTransfer sample project

### DIFF
--- a/Source/FileList.cpp
+++ b/Source/FileList.cpp
@@ -348,7 +348,7 @@ void FileList::AddFilesFromDirectory(const char *applicationDirectory, const cha
 					fclose(fp);
 
 					// File data only
-					AddFile(fullPath+rootLen, fullPath, fileData, fileInfo.size, fileInfo.size, context);
+					AddFile(fullPath, fullPath, fileData, fileInfo.size, fileInfo.size, context); // According to FileListTransfer sample project, the first parameter of AddFile() seem to have to be the full path.
 				}
 				else
 				{


### PR DESCRIPTION
The original FileListTransfer sample project only supports transferring a single file. This pull request makes it support multiple files, directories, and all forms of combinations. A non-sample source file, FileList.cpp, is changed to fix FileList::AddFilesFromDirectory() when writing data only.

I reckon the change in FileList.cpp is safe for the following reasons:
- FileList does not seem to be a core class in RakNet.
- None of the existing cases when FileList::AddFilesFromDirectory() is called executes the route of the code that's changed, namely when and only when `writeData` is `true`.
- The original prompt of FileListTransfer sample project suggests the first parameter of FileList::AddFile() needs to be the full path.
- In the tests, not passing the full path as the first parameter of FileList::AddFile() results in failures.